### PR TITLE
Allow build to run on main after automerge

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -20,4 +20,4 @@ jobs:
         run: gh pr merge --rebase --auto "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GITHUB_TOKEN: ${{secrets.AUTOMERGE_TOKEN}}

--- a/.github/workflows/pr-automerge.yml
+++ b/.github/workflows/pr-automerge.yml
@@ -14,4 +14,4 @@ jobs:
         run: gh pr merge --merge --auto "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GITHUB_TOKEN: ${{secrets.AUTOMERGE_TOKEN}}


### PR DESCRIPTION
By using a PAT rather than the default `GITHUB_TOKEN`

See https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow
