### PR TITLE
Allow build to run on main after automerge

### DIFF
--- a/.github/workflows/pr-automerge.yml
+++ b/.github/workflows/pr-automerge.yml
@@ -1,4 +1,4 @@
-name: Dependabot auto-merge
+name: PR auto-merge
 on: pull_request
 
 permissions:


### PR DESCRIPTION
By using a PAT rather than the default `GITHUB_TOKEN`

See https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow
